### PR TITLE
Fixed improper PHP header(...) function usage

### DIFF
--- a/data_game/admin.php
+++ b/data_game/admin.php
@@ -1,6 +1,14 @@
 <?php
     require "../database/member_info.php";
     session_start();
+
+    include 'auth.php';
+    $res = callCheck();
+
+    // only an admin can modify the post of the low ranked members (coordinator and/or member)
+    if ($res != 2) {
+        exit();
+    }
 ?>
 
 <?php
@@ -21,6 +29,7 @@
             $query_run = mysqli_query($connection,$query);
             // echo $admin_value;
             header('location:../geekhaven/makeAdmin.php');
+            die();
         }else{
             echo 'error';
         }

--- a/data_game/ann.php
+++ b/data_game/ann.php
@@ -23,6 +23,7 @@
                     $query = "INSERT INTO announcements VALUES('$member_id','$name','$organiser','$venue','$date','$time','$topic','$details','$link','$attach','$image')";
                     $query_run = mysqli_query($connection,$query);
                     header('location:../geekhaven/announcement.php');                
+                    die();
                 }                
 
             }
@@ -34,6 +35,7 @@
                     $query = "DELETE FROM announcements WHERE `name`='$name'";
                     $query_run = mysqli_query($connection,$query);
                     header('location:../geekhaven/announcement.php');
+                    die();
                 }else{
                     echo "error : CANNOT DELETE";
                 }

--- a/data_game/announce.php
+++ b/data_game/announce.php
@@ -23,6 +23,7 @@
                     $query = "INSERT INTO announcements VALUES('$member_id','$name','$organiser','$venue','$date','$time','$topic','$details','$link','$attach','$image')";
                     $query_run = mysqli_query($connection,$query);
                     header('location:../geekhaven/announcement.php');                
+                    die();
                 }                
 
             }
@@ -34,6 +35,7 @@
                     $query = "DELETE FROM announcements WHERE `name`='$name'";
                     $query_run = mysqli_query($connection,$query);
                     header('location:../geekhaven/announcement.php');
+                    die();
                 }else{
                     echo "error : CANNOT DELETE";
                 }

--- a/data_game/hof.php
+++ b/data_game/hof.php
@@ -11,6 +11,7 @@
             $query = "UPDATE member SET `hof`='$hof_value' WHERE `member_id`='$memID'";
             $query_run = mysqli_query($connection,$query);
             header('location:../geekhaven/makehof.php');
+            die();
         }else{
             echo 'error';
         }

--- a/data_game/projectdata.php
+++ b/data_game/projectdata.php
@@ -19,6 +19,7 @@
                     $query_run = mysqli_query($connection,$query);
                     
                     header('location:../geekhaven/project.php');   
+                    die();
                 }
             }
             if(isset($_POST['select_pro_btn'])){
@@ -32,6 +33,7 @@
                     $query_run = mysqli_query($connection,$query);
                     
                     header('location:../geekhaven/project.php');                
+                    die();
                 }else{
                     echo "error : CANNOT REMOVE";
                 }

--- a/data_game/saveblog.php
+++ b/data_game/saveblog.php
@@ -16,6 +16,7 @@
                     $query = " INSERT INTO blogs VALUES('$wingID','$member_id','$blog_title','$des','$blog_link','$image')";
                     $query_run = mysqli_query($connection,$query);
                     header('location:../geekhaven/blog.php');
+                    die();
                 }
             }
             if(isset($_POST['select_blog_btn'])){
@@ -26,6 +27,7 @@
                     $query = "DELETE FROM blogs WHERE `blog_title`='$name'";
                     $query_run = mysqli_query($connection,$query);
                     header('location:../geekhaven/blog.php');
+                    die();
                 }else{
                     echo "error : CANNOT REMOVE";
                 }

--- a/data_game/savemem.php
+++ b/data_game/savemem.php
@@ -1,6 +1,14 @@
 <?php
     require "../database/member_info.php";
     session_start();
+
+    include 'auth.php';
+    $res = callCheck();
+
+    // admin or coordinators can add members
+    if (!($res == 2 || $res == 1)) {
+        exit();
+    }
 ?>
 
 <?php
@@ -34,6 +42,7 @@
                         $query = "INSERT INTO credentials VALUES('$cred_id','$username','$pass','0','$member_id')";
                         $query_run = mysqli_query($connection,$query);
                         header('location:../geekhaven/addmember.php');
+                        die();
                     }
                 }
             }
@@ -68,6 +77,7 @@
                     
                     echo $query;
                     header('location:../geekhaven/addmember.php');
+                    die();
                 }else{
                     echo "CANNOT REMOVE";
                 }
@@ -88,5 +98,6 @@
                 $query = "DELETE FROM social_handles WHERE `social_handles_id`='$handle_id'";
                 $query_run = mysqli_query($connection,$query);
                 header('location:../geekhaven/addmember.php');
+                die();
             }
 ?>

--- a/data_game/savewing.php
+++ b/data_game/savewing.php
@@ -1,6 +1,15 @@
 <?php
     require "../database/wingsdb.php";    
     session_start();
+
+    include 'auth.php';
+    $res = callCheck();
+
+    // only an admin can add/modify a wing, conditionals can be used for specific tasks - add/update/remove
+    // like admin can add / remove a wing, and coordinators can update their respective wing
+    if ($res != 2) {
+        exit();
+    }
 ?>
 
 <?php
@@ -19,7 +28,7 @@
                 $query = "INSERT INTO wings VALUES('$wing_id','$wing','$info','$logo','$image')" ;
                 $query_run = mysqli_query($connection,$query); 
                 header('location:../geekhaven/wing.php'); 
-
+                die();
             }   
         }
 
@@ -47,7 +56,7 @@
             }
 
             header('location:../geekhaven/wing.php');     
-                  
+            die();
         }
         if(isset($_POST['remove_btn'])){
             $wing_id = $_SESSION['wingID'];
@@ -57,6 +66,6 @@
             $query = "DELETE FROM wings WHERE `wing_id`='$wing_id'" ;  
             $query_run = mysqli_query($connection,$query);
             header('location:../geekhaven/wing.php');     
-                  
+            die();
         }
 ?>

--- a/geekhaven/addmember.php
+++ b/geekhaven/addmember.php
@@ -6,6 +6,7 @@
     $res = callCheck();
     if($res<1){
         header('location:login.php');        
+        die();
     }
 ?>
 <!DOCTYPE html>

--- a/geekhaven/auth.php
+++ b/geekhaven/auth.php
@@ -10,10 +10,13 @@
             }else if($_COOKIE[$cookie_name]==$t + $cookie_name){
                 return 0;
             }else{
+                // we can 'return -1' for any invalid user, I am not changing the logic here
                 header('location:login.php');
+                die();
             }
         }else{
             header('location:login.php');
+            die();
         }
     }
     function callCheck(){

--- a/geekhaven/geekhavenData.php
+++ b/geekhaven/geekhavenData.php
@@ -6,6 +6,7 @@
     $res = callCheck();
     if($res<1){
         header('location:login.php');        
+        die();
     }
 ?>
 <!DOCTYPE html>

--- a/geekhaven/login.php
+++ b/geekhaven/login.php
@@ -7,6 +7,7 @@
     
     if(isset($_COOKIE[$cookie_name])){
         header('location:home.php');
+        die();
     }
 ?>
 <!DOCTYPE html>

--- a/geekhaven/makeAdmin.php
+++ b/geekhaven/makeAdmin.php
@@ -6,6 +6,7 @@
     $res = callCheck();
     if($res<1){
         header('location:login.php');        
+        die();
     }
 ?>
 <!DOCTYPE html>

--- a/geekhaven/makehof.php
+++ b/geekhaven/makehof.php
@@ -6,6 +6,7 @@
     $res = callCheck();
     if($res<1){
         header('location:login.php');        
+        die();
     }
 ?>
 <!DOCTYPE html>


### PR DESCRIPTION
@garvitchittora I have made changes accordingly, that is only the required edits.
It was hard for me as well to re-apply the fix reading the `Compare code`, I have tried to keep it simple this time.

# Problem
Improper PHP `header(...)` function usage, it caused leak of some information and allowed database modification.
I can not provide the exact details and procedure here about the exploitation.

The issue here was that after the `header(...)` call in the __PHP__ files, the user is __redirected__ to the provided url but the rest of the page is still __processed__ / __rendered__. So the user gets the __response__ with the data that they __shouldn't receive__ but they are presented with the later (__redirected__) page. The earlier processed __response__ is also received but is appended to the __local HTTP History__ - this can easily be viewed by using __BurpSuite__ (for example)

There are other issues as well other than this improper PHP `header(...)` function usage.
I haven't fixed them, it would require me to change __large chunks__ of the code, let me know if I should that.

> NOTE
There may still be some issues with the reported one, I have patched or at least tried to patch the issues that I have found

`SQLi` is also present in multiple pages.